### PR TITLE
fix: Harden security by defining workflow permissions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   shellcheck:
     name: Shellcheck Runner


### PR DESCRIPTION
This addresses the CodeQL warning by explicitly setting read-only permissions for the CI workflow.
